### PR TITLE
fix: don't crash when can't identify device of the user-config history file

### DIFF
--- a/packages/uhk-agent/src/util/load-user-config-history-async.ts
+++ b/packages/uhk-agent/src/util/load-user-config-history-async.ts
@@ -1,11 +1,12 @@
 import { readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
-import { convertHistoryFilenameToDisplayText } from 'uhk-common';
-import { getMd5HashFromFilename } from 'uhk-common';
 import {
+    convertHistoryFilenameToDisplayText,
     DeviceUserConfigHistory,
+    getMd5HashFromFilename,
     sortStringDesc,
     UHK_DEVICES,
+    UNKNOWN_DEVICE,
     UserConfigHistory,
 } from 'uhk-common';
 
@@ -49,7 +50,7 @@ export async function loadUserConfigHistoryAsync(): Promise<UserConfigHistory> {
             const deviceHistoryDir = path.join(userConfigHistoryDir, entry);
             const deviceHistory: DeviceUserConfigHistory = {
                 uniqueId: Number.parseInt(entrySplit[0], 10),
-                device: UHK_DEVICES.find(device => device.id === deviceId),
+                device: UHK_DEVICES.find(device => device.id === deviceId) || UNKNOWN_DEVICE,
                 deviceName: '',
                 files: (await readdir(deviceHistoryDir))
                     .filter(file => path.extname(file) === '.bin')

--- a/packages/uhk-common/src/models/uhk-products.ts
+++ b/packages/uhk-common/src/models/uhk-products.ts
@@ -17,6 +17,15 @@ export interface UhkDeviceProduct {
     buspalPid: number;
 }
 
+export const UNKNOWN_DEVICE: UhkDeviceProduct = {
+    id: 0 as UHK_DEVICE_IDS_TYPE,
+    vendorId: 0,
+    bootloaderPid: 0,
+    buspalPid: 0,
+    keyboardPid: 0,
+    name: 'Unknown'
+};
+
 export const UHK_60_DEVICE: UhkDeviceProduct = {
     id: UHK_DEVICE_IDS.UHK60V1_RIGHT,
     name: 'UHK 60 v1',


### PR DESCRIPTION
closes: UltimateHackingKeyboard/agent#2383