### PR TITLE
feat: upgrade dongle via USB script

### DIFF
--- a/packages/uhk-common/src/models/hardware-modules.ts
+++ b/packages/uhk-common/src/models/hardware-modules.ts
@@ -8,6 +8,7 @@ export interface ModuleInfo {
 }
 
 export interface HardwareModules {
+    dongleInfo?: RightModuleInfo;
     moduleInfos?: ModuleInfo[];
     rightModuleInfo?: RightModuleInfo;
 }

--- a/packages/uhk-common/src/models/uhk-products.ts
+++ b/packages/uhk-common/src/models/uhk-products.ts
@@ -148,6 +148,28 @@ export const UHK_80_DEVICE: UhkDeviceProduct = {
     reportId: 4,
 };
 
+export const UHK_DONGLE: UhkDeviceProduct = {
+    id: UHK_DEVICE_IDS.UHK_DONGLE,
+    firmwareUpgradeMethod: FIRMWARE_UPGRADE_METHODS.MCUBOOT,
+    logName: 'UHK Dongle',
+    name: 'UHK Dongle',
+    keyboard: [
+        {
+            vid: UHK_VENDOR_ID,
+            pid: 0x0005, // decimal 5
+        },
+    ],
+    bootloader: [
+        {
+            vid: UHK_VENDOR_ID,
+            pid: 0x0004, // decimal 4
+        },
+    ],
+    // TODO: Implement when we know
+    buspal: [],
+    reportId: 4,
+};
+
 export const UHK_DEVICES: Array<UhkDeviceProduct> = [
     UHK_60_DEVICE,
     UHK_60_V2_DEVICE,

--- a/packages/uhk-usb/src/utils/get-uhk-dongles.ts
+++ b/packages/uhk-usb/src/utils/get-uhk-dongles.ts
@@ -1,0 +1,8 @@
+import { Device, devices } from 'node-hid';
+import { UHK_DONGLE } from 'uhk-common';
+
+import { isUhkCommunicationUsage } from '../util.js';
+
+export function getUhkDongles(): Array<Device> {
+    return devices().filter(x => UHK_DONGLE.keyboard.some(vidPid => x.vendorId === vidPid.vid && x.productId === vidPid.pid && isUhkCommunicationUsage(x)));
+}

--- a/packages/uhk-usb/src/utils/index.ts
+++ b/packages/uhk-usb/src/utils/index.ts
@@ -14,6 +14,7 @@ export * from './get-module-firmware-path.js';
 export * from './get-number-of-connected-devices.js';
 export * from './get-package-json-from-path-async.js';
 export * from './get-uhk-devices.js';
+export * from './get-uhk-dongles.js';
 export * from './is-uhk-device-connected.js';
 export * from './validate-connected-devices.js';
 export { default as readUhkResponseAs0EndString } from './read-uhk-response-as-0-end-string.js';

--- a/packages/usb/get-right-firmware-version.ts
+++ b/packages/usb/get-right-firmware-version.ts
@@ -5,7 +5,7 @@ import Uhk, { errorHandler, yargs } from './src/index.js';
 (async function () {
     try {
         const argv = yargs
-            .usage('Get Left firmware version')
+            .usage('Get Right firmware version')
             .argv;
 
         const { operations } = Uhk(argv);
@@ -17,6 +17,9 @@ import Uhk, { errorHandler, yargs } from './src/index.js';
         console.log(`userConfigVersion: ${version.userConfigVersion}`);
         console.log(`hardwareConfigVersion: ${version.hardwareConfigVersion}`);
         console.log(`smartMacrosVersion: ${version.smartMacrosVersion}`);
+        console.log(`firmwareGitRepo: ${version.firmwareGitRepo}`);
+        console.log(`firmwareGitTag: ${version.firmwareGitTag}`);
+        console.log(`firmwareChecksum: ${version.firmwareChecksum}`);
     } catch (error) {
         errorHandler(error);
     }

--- a/packages/usb/reenumerate.ts
+++ b/packages/usb/reenumerate.ts
@@ -6,6 +6,7 @@ import {
     UHK_80_DEVICE,
     UHK_80_DEVICE_LEFT,
     UHK_DEVICES,
+    UHK_DONGLE,
     UhkDeviceProduct,
 } from 'uhk-common';
 import {
@@ -66,6 +67,7 @@ async function getCurrentUhkDeviceProduct(argv: any): Promise<UhkDeviceProduct |
     const allUhkDevice = [
         ...UHK_DEVICES,
         UHK_80_DEVICE_LEFT,
+        UHK_DONGLE,
     ];
 
     for (const hidDevice of hidDevices) {
@@ -86,7 +88,8 @@ async function getCurrentUhkDeviceProduct(argv: any): Promise<UhkDeviceProduct |
 
     const uhk80Devices = [
         UHK_80_DEVICE_LEFT,
-        UHK_80_DEVICE
+        UHK_80_DEVICE,
+        UHK_DONGLE,
     ];
 
     for (const serialDevice of serialDevices) {

--- a/packages/usb/update-dongle-firmware.ts
+++ b/packages/usb/update-dongle-firmware.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S node --loader ts-node/esm --no-warnings=ExperimentalWarning
+
+import { existsSync } from 'fs';
+import { UHK_DONGLE } from 'uhk-common';
+import { getUhkDongles } from 'uhk-usb';
+
+import Uhk, { errorHandler, yargs } from './src/index.js';
+
+(async () => {
+    try {
+        const argv = yargs
+            .scriptName('./update-dongle-firmware')
+            .usage('Usage: $0 <firmware path>')
+            .demandCommand(1, 'Firmware path is required')
+            .argv as any;
+
+        const firmwarePath = argv._[0];
+
+        if (!existsSync(firmwarePath)) {
+            console.log('Firmware path does not exists.');
+            process.exit(1);
+        }
+
+        const dongles = getUhkDongles();
+
+        if (dongles.length === 0) {
+            console.log('UHK Dongle not connected');
+            process.exit(1);
+        }
+
+        if (dongles.length > 1) {
+            console.log('More then 1 UHK Dongle connected');
+            process.exit(1) ;
+        }
+
+        const { operations } = Uhk(argv);
+        console.log(`Updating Dongle firmware from ${firmwarePath} ...`);
+        await operations.updateDeviceFirmware(firmwarePath, UHK_DONGLE);
+        console.log('Firmware updated.');
+        console.log('Reenumerating device...');
+
+    } catch (error) {
+        errorHandler(error);
+    }
+})();


### PR DESCRIPTION
Summary:
- created the new `./packages/usb/update-dongle-firmware.ts` that upgrade the firmware of the UHK dongle
- extended the `./packages/usb/reenumerate.ts` to support the reenumeration of UHK dongle
- extended the `./packages/usb/get-right-firmware-version.ts` to print the `firmwareGitRepo`, `firmwareGitTag`, `firmwareChecksum` information

The `./packages/usb/get-right-firmware-version.ts --vid=14248 --pid=5 --usb-interface=2 --report-id=4` command list the firmware information of the dongle