### PR TITLE
fix: remove `s` of led fadeout timeouts above 60 seconds

### DIFF
--- a/packages/uhk-web/src/app/components/device/led-settings/fade-timeout-slider.component.ts
+++ b/packages/uhk-web/src/app/components/device/led-settings/fade-timeout-slider.component.ts
@@ -141,6 +141,6 @@ export class FadeTimeoutSliderComponent implements ControlValueAccessor{
             secs = '00';
         }
 
-        return `${mins}:${secs} s`;
+        return `${mins}:${secs}`;
     }
 }


### PR DESCRIPTION
closes UltimateHackingKeyboard/agent#2397