### PR TITLE
fix: set key color of uninitialised NoneAction

### DIFF
--- a/packages/uhk-web/src/app/store/reducers/user-configuration.ts
+++ b/packages/uhk-web/src/app/store/reducers/user-configuration.ts
@@ -401,7 +401,11 @@ export function reducer(
 
                         module = new Module(module);
                         const selectedColor = state.backlightingColorPalette[state.selectedBacklightingColorIndex];
-                        const keyAction = KeyActionHelper.fromKeyAction(module.keyActions[payload.key]);
+                        let keyAction = KeyActionHelper.fromKeyAction(module.keyActions[payload.key]);
+                        if (!keyAction) {
+                            keyAction = new NoneAction();
+                        }
+
                         keyAction.b = selectedColor.b;
                         keyAction.g = selectedColor.g;
                         keyAction.r = selectedColor.r;


### PR DESCRIPTION
closes UltimateHackingKeyboard/agent#2398

This PR fixes only the crash.

The top left key of the left half already has a none action because the uhk60 iso layer has 1 more action.
These anomaly will fix be fixed if we implement the UltimateHackingKeyboard/agent#2378 story