### PR TITLE
fix: remapInfo mutability on the popover component

### DIFF
--- a/packages/uhk-web/src/app/components/popover/popover.component.html
+++ b/packages/uhk-web/src/app/components/popover/popover.component.html
@@ -23,7 +23,7 @@
                       [defaultKeyAction]="shadowKeyAction"
                       [secondaryRoleEnabled]="true"
                       [allowRemapOnAllKeymapWarning]="true"
-                      [remapInfo]="remapInfo"
+                      [remapInfo]="internalRemapInfo"
                       [secondaryRoleOptions]="secondaryRoleOptions"
                       (validAction)="setKeyActionValidState($event)"
                       (keyActionChange)="keystrokeActionChange($event)"
@@ -44,7 +44,7 @@
                    [selectedKey]="selectedKey"
                    [defaultKeyAction]="defaultKeyAction"
                    [macroPlaybackSupported]="macroPlaybackSupported$ | async"
-                   [remapInfo]="remapInfo"
+                   [remapInfo]="internalRemapInfo"
                    (assignNewMacro)="onAssignNewMacro()"
                    (validAction)="setKeyActionValidState($event)"
         ></macro-tab>
@@ -67,7 +67,7 @@
                     <input type="checkbox" class="form-check-input"
                         id="remapOnAllKeymap"
                         name="remapOnAllKeymap"
-                        [(ngModel)]="remapInfo.remapOnAllKeymap">
+                        [(ngModel)]="internalRemapInfo.remapOnAllKeymap">
                     <label class="form-check-label" for="remapOnAllKeymap">Remap on all keymaps</label>
                 </div>
                 <div class="form-check">
@@ -75,7 +75,7 @@
                         class="form-check-input"
                         id="remapOnAllLayer"
                         name="remapOnAllLayer"
-                        [(ngModel)]="remapInfo.remapOnAllLayer"
+                        [(ngModel)]="internalRemapInfo.remapOnAllLayer"
                         [disabled]="disableRemapOnAllLayer"
                         (ngModelChange)="remapInfoChange()">
                     <label class="form-check-label"

--- a/packages/uhk-web/src/app/components/popover/popover.component.ts
+++ b/packages/uhk-web/src/app/components/popover/popover.component.ts
@@ -93,6 +93,7 @@ export class PopoverComponent implements OnChanges {
     keymapOptions$: Observable<SelectOptionData[]>;
     shadowKeyAction: KeyAction;
     disableRemapOnAllLayer = false;
+    internalRemapInfo: RemapInfo;
     tabHeaders: TabHeader[] = [
         {
             tabName: TabName.Keypress,
@@ -140,6 +141,12 @@ export class PopoverComponent implements OnChanges {
     ngOnChanges(change: SimpleChanges) {
         let tab: TabHeader = this.tabHeaders[5];
 
+        if (change.remapInfo) {
+            this.internalRemapInfo = {
+                ...this.remapInfo,
+            };
+        }
+
         if (change['defaultKeyAction']) {
             this.disableRemapOnAllLayer = false;
 
@@ -174,8 +181,8 @@ export class PopoverComponent implements OnChanges {
 
     onAssignNewMacro(): void {
         this.remap.emit({
-            remapOnAllKeymap: this.remapInfo.remapOnAllKeymap,
-            remapOnAllLayer: this.remapInfo.remapOnAllLayer,
+            remapOnAllKeymap: this.internalRemapInfo.remapOnAllKeymap,
+            remapOnAllLayer: this.internalRemapInfo.remapOnAllLayer,
             assignNewMacro: true
         });
     }
@@ -188,8 +195,8 @@ export class PopoverComponent implements OnChanges {
         if (this.keyActionValid) {
             try {
                 this.remap.emit({
-                    remapOnAllKeymap: this.remapInfo.remapOnAllKeymap,
-                    remapOnAllLayer: this.remapInfo.remapOnAllLayer,
+                    remapOnAllKeymap: this.internalRemapInfo.remapOnAllKeymap,
+                    remapOnAllLayer: this.internalRemapInfo.remapOnAllLayer,
                     action: this.selectedTab.toKeyAction()
                 });
             } catch (e) {
@@ -224,7 +231,7 @@ export class PopoverComponent implements OnChanges {
     }
 
     remapInfoChange(): void {
-        this.selectedTab.remapInfoChanged(this.remapInfo);
+        this.selectedTab.remapInfoChanged(this.internalRemapInfo);
     }
 
     keystrokeActionChange(keystrokeAction: KeystrokeAction): void {
@@ -240,7 +247,7 @@ export class PopoverComponent implements OnChanges {
             this.disableRemapOnAllLayer = disableRemapOnAllLayer;
 
             if (disableRemapOnAllLayer) {
-                this.remapInfo.remapOnAllLayer = false;
+                this.internalRemapInfo.remapOnAllLayer = false;
             }
 
             this.cdRef.markForCheck();


### PR DESCRIPTION
It is a technical PR. Error occurred when we run the web build and wanted to modify a key action on the base layer that has mod, fn, mouse secondary role.