### PR TITLE
fix: start to load user config if Agent can connect to UHK and udevInfo is UdevDirNotExists

### DIFF
--- a/packages/uhk-web/src/app/store/effects/device.ts
+++ b/packages/uhk-web/src/app/store/effects/device.ts
@@ -171,7 +171,7 @@ export class DeviceEffects {
                 if (connected
                     && payload.hasPermission
                     && payload.communicationInterfaceAvailable
-                    && payload.udevRulesInfo === UdevRulesInfo.Ok) {
+                    && (payload.udevRulesInfo === UdevRulesInfo.Ok || payload.udevRulesInfo === UdevRulesInfo.UdevDirNotExists)) {
 
                     const result: Array<Action> = [
                         new ReadConfigSizesAction(),


### PR DESCRIPTION
closed UltimateHackingKeyboard/agent#2401