### PR TITLE
fix: USB powered OLED fade timeout to 5 minutes

### DIFF
--- a/packages/uhk-web/src/app/services/user-config-80.json
+++ b/packages/uhk-web/src/app/services/user-config-80.json
@@ -74,7 +74,7 @@
   "keyBacklightBrightnessBattery": 255,
   "displayFadeOutTimeout": 300,
   "displayFadeOutBatteryTimeout": 10,
-  "keyBacklightFadeOutTimeout": 0,
+  "keyBacklightFadeOutTimeout": 300,
   "keyBacklightFadeOutBatteryTimeout": 10,
   "hostConnections": [
     {


### PR DESCRIPTION
closes: [#115](https://github.com/UltimateHackingKeyboard/agent/issues/2406)